### PR TITLE
feat: Add LCD display support, WATERFORCE X II

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,3 @@
 modules.order
 Module.symvers
 Mkfile.old
-dkms.conf
-

--- a/Documentation/hwmon/gigabyte_waterforce.rst
+++ b/Documentation/hwmon/gigabyte_waterforce.rst
@@ -5,11 +5,14 @@ Kernel driver gigabyte_waterforce
 
 Supported devices:
 
-* Gigabyte AORUS WATERFORCE X240
-* Gigabyte AORUS WATERFORCE X280
-* Gigabyte AORUS WATERFORCE X360
+* Gigabyte AORUS WATERFORCE X 240 (USB ID 1044:7a4d)
+* Gigabyte AORUS WATERFORCE X 280 (USB ID 1044:7a4d)
+* Gigabyte AORUS WATERFORCE X 360 (USB ID 1044:7a4d)
+* Gigabyte AORUS WATERFORCE X II 240 (USB ID 0414:7a5e)
+* Gigabyte AORUS WATERFORCE X II 280 (USB ID 0414:7a5e)
+* Gigabyte AORUS WATERFORCE X II 360 (USB ID 0414:7a5e)
 
-Author: Aleksa Savic
+Authors: Aleksa Savic, Vasily Sokolov
 
 Description
 -----------
@@ -21,14 +24,53 @@ well as coolant temperature. Also available through debugfs is the firmware vers
 Attaching a fan is optional and allows it to be controlled from the device. If
 it's not connected, the fan-related sensors will report zeroes.
 
-The addressable RGB LEDs and LCD screen are not supported in this driver and should
-be controlled through userspace tools.
+The addressable RGB LEDs are not supported in this driver and should be controlled
+through userspace tools (e.g. OpenRGB).
+
+LCD display
+-----------
+
+This fork adds LCD display update support. The driver periodically sends the
+following information to the cooler display:
+
+* CPU temperature (read from a configurable hwmon sensor, default: ``Tctl``)
+* CPU frequency (read from the cpufreq subsystem)
+* CPU usage (computed from kernel tick counters)
+* CPU package power (read from a configurable hwmon sensor, default: ``RAPL_P_Package``)
+
+The sensor labels used for temperature and power lookup can be overridden via
+module parameters (see below). The driver scans ``/sys/class/hwmon/`` at runtime
+and caches the found sensor paths, retrying automatically if a sensor module is
+loaded after the cooler driver.
 
 Usage notes
 -----------
 
 As these are USB HIDs, the driver can be loaded automatically by the kernel and
 supports hot swapping.
+
+Module parameters
+-----------------
+
+================== ======= ===================================================
+Parameter          Default Description
+================== ======= ===================================================
+lcd_temp_label     Tctl    hwmon sensor label for LCD CPU temperature display
+lcd_power_label    RAPL_P_ hwmon sensor label for LCD CPU power display (W)
+                   Package
+lcd_refresh_ms     2000    LCD update interval in milliseconds (minimum: 100)
+================== ======= ===================================================
+
+To set parameters persistently, create ``/etc/modprobe.d/gigabyte_waterforce.conf``::
+
+    options gigabyte_waterforce lcd_temp_label=Tctl lcd_power_label=Esocket0 lcd_refresh_ms=2000
+
+.. note::
+   The label names refer to values in ``/sys/class/hwmon/hwmon*/temp*_label`` and
+   ``/sys/class/hwmon/hwmon*/power*_label`` respectively. These may differ from
+   sensor names shown by ``lm-sensors``. To find the correct label for your system::
+
+       grep -r '' /sys/class/hwmon/hwmon*/temp*_label /sys/class/hwmon/hwmon*/power*_label 2>/dev/null
 
 Sysfs entries
 -------------

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
-.PHONY: all modules install modules_install clean
+.PHONY: all modules install modules_install clean checkpatch dev \
+        dkms-add dkms-build dkms-install dkms-remove dkms-status
 
-# external KDIR specification is supported
+MODULE_NAME  := gigabyte_waterforce
+MODULE_VER   := $(shell sed -n 's/^PACKAGE_VERSION="\(.*\)"/\1/p' dkms.conf)
+DKMS_SRC     := /usr/src/$(MODULE_NAME)-$(MODULE_VER)
+
+# External KDIR specification is supported
 KDIR ?= /lib/modules/$(shell uname -r)/build
 
 SOURCES := drivers/hwmon/gigabyte_waterforce.c
@@ -15,8 +20,32 @@ modules modules_install clean:
 checkpatch:
 	$(KDIR)/scripts/checkpatch.pl --strict --no-tree $(SOURCES)
 
+# Quick local test cycle (no DKMS)
 dev:
 	make clean
 	make
 	sudo rmmod gigabyte_waterforce || true
 	sudo insmod drivers/hwmon/gigabyte_waterforce.ko
+
+# --- DKMS targets ---
+
+dkms-add:
+	sudo mkdir -p $(DKMS_SRC)
+	sudo cp -r --no-preserve=ownership . $(DKMS_SRC)/
+	sudo dkms add $(MODULE_NAME)/$(MODULE_VER)
+
+dkms-build:
+	sudo dkms build $(MODULE_NAME)/$(MODULE_VER)
+
+dkms-install:
+	sudo dkms install --force $(MODULE_NAME)/$(MODULE_VER)
+
+# Build + install in one step (MOK signing is handled automatically via /etc/dkms/framework.conf)
+dkms: dkms-add dkms-build dkms-install
+
+dkms-remove:
+	sudo dkms remove $(MODULE_NAME)/$(MODULE_VER) --all
+	sudo rm -rf $(DKMS_SRC)
+
+dkms-status:
+	dkms status $(MODULE_NAME)/$(MODULE_VER)

--- a/README.md
+++ b/README.md
@@ -6,32 +6,109 @@ _Hwmon Linux kernel driver for monitoring Gigabyte AORUS Waterforce AIO coolers_
 
 The following devices are supported by this driver:
 
-* Gigabyte AORUS WATERFORCE X240
-* Gigabyte AORUS WATERFORCE X280
-* Gigabyte AORUS WATERFORCE X360
+| Device                              | USB ID     |
+|-------------------------------------|------------|
+| Gigabyte AORUS WATERFORCE X 240     | 1044:7a4d  |
+| Gigabyte AORUS WATERFORCE X 280     | 1044:7a4d  |
+| Gigabyte AORUS WATERFORCE X 360     | 1044:7a4d  |
+| Gigabyte AORUS WATERFORCE X II 240  | 0414:7a5e  |
+| Gigabyte AORUS WATERFORCE X II 280  | 0414:7a5e  |
+| Gigabyte AORUS WATERFORCE X II 360  | 0414:7a5e  |
 
-Being a standard `hwmon` driver, it provides readings via `sysfs`, which are easily accessible through `lm-sensors` as usual.
+Being a standard `hwmon` driver, it provides readings via `sysfs`, accessible through `lm-sensors` as usual.
 
 Report offsets were initially taken from [here](https://github.com/namidairo/liquidctl/commit/a56db61350d01db8c3a008bb8816d870f6f2350d)
-and confirmed by me when I acquired a X240.
+and confirmed when acquiring a X240.
+
+## What this fork adds
+
+This is a fork of the [original driver](https://github.com/aleksamagicka/waterforce-hwmon) by Aleksa Savic,
+extended with the following features:
+
+- **LCD display support** — the driver periodically updates the cooler's LCD with CPU temperature,
+  frequency, usage percentage, and package power. This replaces the need for a separate userspace
+  daemon (e.g. AorusWaterForce360-linux), which conflicts with the kernel driver over the HID channel.
+- **Support for WATERFORCE X II** — added USB ID `0414:7a5e` (X II 240/280/360).
+- **Configurable sensors** — module parameters control which hwmon sensors are used for temperature
+  and power readings.
 
 ## Kernel availability
 
-This driver is mainlined since kernel v6.8. If you need additional features or bugfixes not yet present in the kernel, you can install
-the driver from this repo yourself by following the instructions in the next section.
+The original driver is mainlined since kernel v6.8. This fork contains additional features not yet
+present upstream. Install from this repository using DKMS (recommended) or manually.
 
-## Installation and usage
+## Installation
 
-First, clone the repository by running:
+### DKMS (recommended)
 
-```commandline
-git clone https://github.com/aleksamagicka/waterforce-hwmon.git
+DKMS automatically rebuilds the module on kernel updates.
+
+```bash
+git clone <repo-url>
+cd gigabyte_waterforce-hwmon
+make dkms
 ```
 
-Then, compile it and insert it into the running kernel, replacing the existing instance (if needed):
+To verify the installation:
 
-```commandline
+```bash
+make dkms-status
+```
+
+To remove:
+
+```bash
+make dkms-remove
+```
+
+### Manual (quick test)
+
+Compile and load the module, replacing the running instance if present:
+
+```bash
 make dev
 ```
 
-You can then try running `sensors` and your device(s) should be listed there.
+## Configuration
+
+LCD sensor labels can be overridden via module parameters. The defaults work for most AMD systems:
+
+| Parameter        | Default          | Description                                      |
+|------------------|------------------|--------------------------------------------------|
+| `lcd_temp_label` | `Tctl`           | hwmon label for CPU temperature (°C)             |
+| `lcd_power_label`| `RAPL_P_Package` | hwmon label for CPU package power (W)            |
+| `lcd_refresh_ms` | `2000`           | LCD update interval in milliseconds (min: 100)   |
+
+To find the correct labels for your system:
+
+```bash
+grep -r '' /sys/class/hwmon/hwmon*/temp*_label /sys/class/hwmon/hwmon*/power*_label 2>/dev/null
+```
+
+To set parameters persistently, create `/etc/modprobe.d/gigabyte_waterforce.conf`:
+
+```
+options gigabyte_waterforce lcd_temp_label=Tctl lcd_power_label=Esocket0 lcd_refresh_ms=2000
+```
+
+On startup the driver logs its configuration to `dmesg`:
+
+```
+gigabyte_waterforce: Device:          Gigabyte AORUS WATERFORCE X II 240/280/360
+gigabyte_waterforce:   Firmware:      v43
+gigabyte_waterforce:   Temp sensor:   Tctl
+gigabyte_waterforce:   Power sensor:  RAPL_P_Package
+gigabyte_waterforce:   Refresh:       2000 ms
+```
+
+## Usage
+
+After loading, run `sensors` — the cooler will appear as `waterforce-hid-*`:
+
+```
+waterforce-hid-3-1:00
+Adapter: HID adapter
+fan1:        1234 RPM
+fan2:        2345 RPM
+temp1:        +28.0°C
+```

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,11 @@
+PACKAGE_NAME="gigabyte_waterforce"
+PACKAGE_VERSION="1.0.0"
+
+BUILT_MODULE_NAME[0]="gigabyte_waterforce"
+BUILT_MODULE_LOCATION[0]="drivers/hwmon/"
+DEST_MODULE_LOCATION[0]="/updates/dkms/"
+
+MAKE[0]="make KDIR=/lib/modules/${kernelver}/build"
+CLEAN="make KDIR=/lib/modules/${kernelver}/build clean"
+
+AUTOINSTALL="yes"

--- a/drivers/hwmon/gigabyte_waterforce.c
+++ b/drivers/hwmon/gigabyte_waterforce.c
@@ -3,20 +3,40 @@
  * hwmon driver for Gigabyte AORUS Waterforce AIO CPU coolers: X240, X280 and X360.
  *
  * Copyright 2023 Aleksa Savic <savicaleksa83@gmail.com>
+ * Copyright 2026 Vasily Sokolov <extracker0mail@gmail.com>
  */
 
+#include <linux/cpufreq.h>
 #include <linux/debugfs.h>
+#include <linux/fs.h>
 #include <linux/hid.h>
 #include <linux/hwmon.h>
 #include <linux/jiffies.h>
+#include <linux/kernel_stat.h>
 #include <linux/module.h>
 #include <linux/spinlock.h>
-#include <asm/unaligned.h>
+#include <linux/unaligned.h>
+#include <linux/workqueue.h>
+
+/* LCD command bytes */
+#define LCD_CMD_BYTE0	0x99
+#define LCD_CMD_BYTE1	0xE0
+
+/* Maximum number of hwmon devices and attributes to scan for LCD sensors */
+#define LCD_HWMON_MAX_DEVS	128
+#define LCD_TEMP_ATTR_MAX	32
+#define LCD_POWER_ATTR_MAX	16
+
+/* Minimum LCD refresh interval in ms */
+#define LCD_REFRESH_MS_MIN	100
 
 #define DRIVER_NAME	"gigabyte_waterforce"
 
-#define USB_VENDOR_ID_GIGABYTE		0x1044
-#define USB_PRODUCT_ID_WATERFORCE	0x7a4d	/* Gigabyte AORUS WATERFORCE X240, X280 and X360 */
+#define USB_VENDOR_ID_CHU_YUEN		0x1044
+#define USB_PRODUCT_ID_WATERFORCE_X	0x7a4d	/* Gigabyte AORUS WATERFORCE X 240, X 280, X 360 */
+
+#define USB_VENDOR_ID_GIGABYTE		    0x0414
+#define USB_PRODUCT_ID_WATERFORCE_X_II	0x7a5e	/* Gigabyte AORUS WATERFORCE X II 240, X II 280, X II 360 */
 
 #define STATUS_VALIDITY		(2 * 1000)	/* ms */
 #define MAX_REPORT_LENGTH	6144
@@ -24,8 +44,21 @@
 #define WATERFORCE_TEMP_SENSOR	0xD
 #define WATERFORCE_FAN_SPEED	0x02
 #define WATERFORCE_PUMP_SPEED	0x05
-#define WATERFORCE_FAN_DUTY	0x08
+#define WATERFORCE_FAN_DUTY	    0x08
 #define WATERFORCE_PUMP_DUTY	0x09
+
+/* Module parameters for LCD sensor discovery */
+static char *lcd_temp_label = "Tctl";
+module_param(lcd_temp_label, charp, 0444);
+MODULE_PARM_DESC(lcd_temp_label, "hwmon sensor label for LCD CPU temperature (default: Tctl)");
+
+static char *lcd_power_label = "RAPL_P_Package";
+module_param(lcd_power_label, charp, 0444);
+MODULE_PARM_DESC(lcd_power_label, "hwmon sensor label for LCD CPU power in watts (default: RAPL_P_Package)");
+
+static unsigned int lcd_refresh_ms = 2000;
+module_param(lcd_refresh_ms, uint, 0444);
+MODULE_PARM_DESC(lcd_refresh_ms, "LCD update interval in milliseconds (default: 2000)");
 
 /* Control commands, inner offsets and lengths */
 static const u8 get_status_cmd[] = { 0x99, 0xDA };
@@ -68,6 +101,13 @@ struct waterforce_data {
 	u8 *buffer;
 	int firmware_version;
 	unsigned long updated;	/* jiffies */
+
+	/* LCD update worker */
+	struct delayed_work lcd_work;
+	char lcd_temp_path[256];	/* sysfs path to temp sensor (empty = not yet found) */
+	char lcd_power_path[256];	/* sysfs path to power sensor (empty = not yet found) */
+	u64 lcd_prev_idle;		/* previous aggregate idle ticks for CPU usage delta */
+	u64 lcd_prev_total;		/* previous aggregate total ticks for CPU usage delta */
 };
 
 static umode_t waterforce_is_visible(const void *data,
@@ -286,6 +326,189 @@ static int waterforce_raw_event(struct hid_device *hdev, struct hid_report *repo
 	return 0;
 }
 
+/*
+ * Read an integer value from a sysfs pseudo-file.
+ * Used to read hwmon sensor values (temp*_input, power*_input) from other
+ * kernel drivers without requiring a userspace intermediary.
+ */
+static int waterforce_sysfs_read_long(const char *path, long *val)
+{
+	struct file *f;
+	char buf[32];
+	ssize_t len;
+	loff_t pos = 0;
+
+	f = filp_open(path, O_RDONLY, 0);
+	if (IS_ERR(f))
+		return PTR_ERR(f);
+
+	len = kernel_read(f, buf, sizeof(buf) - 1, &pos);
+	filp_close(f, NULL);
+
+	if (len <= 0)
+		return len < 0 ? len : -EIO;
+
+	buf[len] = '\0';
+	return kstrtol(strim(buf), 10, val);
+}
+
+/*
+ * Scan hwmon devices to find a sensor whose *_label attribute matches
+ * sensor_label. attr_type is "temp" or "power", max_n is the highest
+ * attribute index to try. On success stores the path to the corresponding
+ * *_input file in result and returns 0.
+ */
+static int waterforce_find_hwmon_sensor(const char *sensor_label,
+					const char *attr_type, int max_n,
+					char *result, size_t result_len)
+{
+	char path[256], label_buf[64];
+	struct file *f;
+	ssize_t len;
+	loff_t pos;
+	int hwmon_n, idx;
+
+	for (hwmon_n = 0; hwmon_n < LCD_HWMON_MAX_DEVS; hwmon_n++) {
+		for (idx = 1; idx <= max_n; idx++) {
+			snprintf(path, sizeof(path),
+				 "/sys/class/hwmon/hwmon%d/%s%d_label",
+				 hwmon_n, attr_type, idx);
+
+			f = filp_open(path, O_RDONLY, 0);
+			if (IS_ERR(f))
+				continue;
+
+			pos = 0;
+			len = kernel_read(f, label_buf, sizeof(label_buf) - 1, &pos);
+			filp_close(f, NULL);
+
+			if (len <= 0)
+				continue;
+
+			label_buf[len] = '\0';
+			strim(label_buf);
+
+			if (strcmp(label_buf, sensor_label) == 0) {
+				snprintf(result, result_len,
+					 "/sys/class/hwmon/hwmon%d/%s%d_input",
+					 hwmon_n, attr_type, idx);
+				return 0;
+			}
+		}
+	}
+	return -ENODEV;
+}
+
+/*
+ * Compute overall CPU usage as a percentage by comparing aggregate idle and
+ * total tick counts between consecutive work invocations. Matches the
+ * calculation used by /proc/stat: idle = CPUTIME_IDLE, total = all fields.
+ */
+static int waterforce_get_cpu_usage(struct waterforce_data *priv)
+{
+	u64 idle = 0, total = 0, delta_idle, delta_total;
+	int cpu, i;
+
+	for_each_possible_cpu(cpu) {
+		struct kernel_cpustat ks = kcpustat_cpu(cpu);
+
+		idle += ks.cpustat[CPUTIME_IDLE];
+		for (i = 0; i < NR_STATS; i++)
+			total += ks.cpustat[i];
+	}
+
+	delta_idle  = idle  - priv->lcd_prev_idle;
+	delta_total = total - priv->lcd_prev_total;
+
+	priv->lcd_prev_idle  = idle;
+	priv->lcd_prev_total = total;
+
+	if (delta_total == 0)
+		return 0;
+
+	return clamp_t(int, 100 * (delta_total - delta_idle) / delta_total, 0, 100);
+}
+
+static void waterforce_lcd_work_func(struct work_struct *work)
+{
+	struct waterforce_data *priv =
+		container_of(work, struct waterforce_data, lcd_work.work);
+	long temp_mc, power_uw;
+	int temp_c = 0, power_w = 0, cpu_usage, freq_mhz;
+	u8 *buf;
+
+	/*
+	 * Lazily discover sensor paths. Paths are cached so the scan only
+	 * runs once (or again if a sensor disappears and reappears).
+	 */
+	if (!priv->lcd_temp_path[0])
+		waterforce_find_hwmon_sensor(lcd_temp_label, "temp",
+					     LCD_TEMP_ATTR_MAX,
+					     priv->lcd_temp_path,
+					     sizeof(priv->lcd_temp_path));
+
+	if (!priv->lcd_power_path[0])
+		waterforce_find_hwmon_sensor(lcd_power_label, "power",
+					     LCD_POWER_ATTR_MAX,
+					     priv->lcd_power_path,
+					     sizeof(priv->lcd_power_path));
+
+	/* Read temperature (hwmon reports in millidegrees Celsius) */
+	if (priv->lcd_temp_path[0]) {
+		if (waterforce_sysfs_read_long(priv->lcd_temp_path, &temp_mc) == 0)
+			temp_c = clamp_t(int, temp_mc / 1000, 0, 255);
+		else
+			priv->lcd_temp_path[0] = '\0'; /* sensor gone, retry next time */
+	}
+
+	/* Read power (hwmon reports in microwatts) */
+	if (priv->lcd_power_path[0]) {
+		if (waterforce_sysfs_read_long(priv->lcd_power_path, &power_uw) == 0)
+			power_w = clamp_t(int, power_uw / 1000000, 0, 255);
+		else
+			priv->lcd_power_path[0] = '\0'; /* sensor gone, retry next time */
+	}
+
+	/* CPU usage: delta of kernel tick counters since last invocation */
+	cpu_usage = waterforce_get_cpu_usage(priv);
+
+	/* CPU frequency from cpufreq subsystem (returns kHz, we need MHz) */
+	freq_mhz = cpufreq_quick_get(0) / 1000;
+
+	/*
+	 * Build and send the LCD update payload. Protocol reverse-engineered
+	 * from the AorusWaterForce360-linux Go daemon.
+	 * buf[0..1] = command { 0x99, 0xE0 }
+	 * buf[3]    = CPU temperature in degrees C
+	 * buf[4]    = 0x10 (temperature field marker)
+	 * buf[5]    = CPU frequency, integer GHz
+	 * buf[6]    = CPU frequency, first decimal digit (100 MHz resolution)
+	 * buf[7]    = 0x08 (frequency field marker)
+	 * buf[8]    = 0x18 (frequency field marker)
+	 * buf[10]   = CPU usage in percent
+	 * buf[11]   = CPU package power in watts
+	 */
+	mutex_lock(&priv->buffer_lock);
+	buf = priv->buffer;
+	memset(buf, 0, MAX_REPORT_LENGTH);
+	buf[0]  = LCD_CMD_BYTE0;
+	buf[1]  = LCD_CMD_BYTE1;
+	buf[3]  = (u8)temp_c;
+	buf[4]  = 0x10;
+	buf[5]  = (u8)(freq_mhz / 1000);
+	buf[6]  = (u8)((freq_mhz / 100) % 10);
+	buf[7]  = 0x08;
+	buf[8]  = 0x18;
+	buf[10] = (u8)cpu_usage;
+	buf[11] = (u8)power_w;
+	hid_hw_output_report(priv->hdev, buf, MAX_REPORT_LENGTH);
+	mutex_unlock(&priv->buffer_lock);
+
+	schedule_delayed_work(&priv->lcd_work,
+			      msecs_to_jiffies(max(lcd_refresh_ms,
+						   (unsigned int)LCD_REFRESH_MS_MIN)));
+}
+
 static int firmware_version_show(struct seq_file *seqf, void *unused)
 {
 	struct waterforce_data *priv = seqf->private;
@@ -311,6 +534,7 @@ static void waterforce_debugfs_init(struct waterforce_data *priv)
 
 static int waterforce_probe(struct hid_device *hdev, const struct hid_device_id *id)
 {
+	const char *model_name = (const char *)id->driver_data;
 	struct waterforce_data *priv;
 	int ret;
 
@@ -360,6 +584,7 @@ static int waterforce_probe(struct hid_device *hdev, const struct hid_device_id 
 	spin_lock_init(&priv->status_report_request_lock);
 	init_completion(&priv->status_report_received);
 	init_completion(&priv->fw_version_processed);
+	INIT_DELAYED_WORK(&priv->lcd_work, waterforce_lcd_work_func);
 
 	hid_device_io_start(hdev);
 	ret = waterforce_get_fw_ver(hdev);
@@ -376,6 +601,16 @@ static int waterforce_probe(struct hid_device *hdev, const struct hid_device_id 
 
 	waterforce_debugfs_init(priv);
 
+	schedule_delayed_work(&priv->lcd_work,
+			      msecs_to_jiffies(max(lcd_refresh_ms,
+						   (unsigned int)LCD_REFRESH_MS_MIN)));
+
+	hid_info(hdev, "Device:          %s", model_name);
+	hid_info(hdev, "  Firmware:      v%d", priv->firmware_version);
+	hid_info(hdev, "  Temp sensor:   %s", lcd_temp_label);
+	hid_info(hdev, "  Power sensor:  %s", lcd_power_label);
+	hid_info(hdev, "  Refresh:       %u ms", lcd_refresh_ms);
+
 	return 0;
 
 fail_and_close:
@@ -389,6 +624,7 @@ static void waterforce_remove(struct hid_device *hdev)
 {
 	struct waterforce_data *priv = hid_get_drvdata(hdev);
 
+	cancel_delayed_work_sync(&priv->lcd_work);
 	debugfs_remove_recursive(priv->debugfs);
 	hwmon_device_unregister(priv->hwmon_dev);
 
@@ -397,7 +633,14 @@ static void waterforce_remove(struct hid_device *hdev)
 }
 
 static const struct hid_device_id waterforce_table[] = {
-	{ HID_USB_DEVICE(USB_VENDOR_ID_GIGABYTE, USB_PRODUCT_ID_WATERFORCE) },
+	{
+		HID_USB_DEVICE(USB_VENDOR_ID_CHU_YUEN, USB_PRODUCT_ID_WATERFORCE_X),
+		.driver_data = (unsigned long)"Gigabyte AORUS WATERFORCE X 240/280/360"
+	},
+	{
+		HID_USB_DEVICE(USB_VENDOR_ID_GIGABYTE, USB_PRODUCT_ID_WATERFORCE_X_II),
+		.driver_data = (unsigned long)"Gigabyte AORUS WATERFORCE X II 240/280/360"
+	},
 	{ }
 };
 
@@ -426,5 +669,5 @@ late_initcall(waterforce_init);
 module_exit(waterforce_exit);
 
 MODULE_LICENSE("GPL");
-MODULE_AUTHOR("Aleksa Savic <savicaleksa83@gmail.com>");
+MODULE_AUTHOR("Aleksa Savic <savicaleksa83@gmail.com>, Vasily Sokolov <extracker0mail@gmail.com>");
 MODULE_DESCRIPTION("Hwmon driver for Gigabyte AORUS Waterforce AIO coolers");


### PR DESCRIPTION
## What this PR adds

- LCD display support — the driver periodically updates the cooler's LCD with CPU temperature, frequency, usage percentage, and package power. This replaces the need for a separate userspace daemon (e.g. AorusWaterForce360-linux), which conflicts with the kernel driver over the HID channel.
- Support for WATERFORCE X II — added USB ID 0414:7a5e (X II 240/280/360).
- Configurable sensors — module parameters control which hwmon sensors are used for temperature and power readings.

## Configuration

LCD sensor labels can be overridden via module parameters. The defaults work for most AMD systems:

| Parameter        | Default          | Description                                      |
|------------------|------------------|--------------------------------------------------|
| `lcd_temp_label` | `Tctl`           | hwmon label for CPU temperature (°C)             |
| `lcd_power_label`| `RAPL_P_Package` | hwmon label for CPU package power (W)            |
| `lcd_refresh_ms` | `2000`           | LCD update interval in milliseconds (min: 100)   |

To find the correct labels for your system:

```bash
grep -r '' /sys/class/hwmon/hwmon*/temp*_label /sys/class/hwmon/hwmon*/power*_label 2>/dev/null
```

To set parameters persistently, create `/etc/modprobe.d/gigabyte_waterforce.conf`:

```
options gigabyte_waterforce lcd_temp_label=Tctl lcd_power_label=Esocket0 lcd_refresh_ms=2000
```

On startup the driver logs its configuration to `dmesg`:

```
gigabyte_waterforce: Device:          Gigabyte AORUS WATERFORCE X II 240/280/360
gigabyte_waterforce:   Firmware:      v43
gigabyte_waterforce:   Temp sensor:   Tctl
gigabyte_waterforce:   Power sensor:  RAPL_P_Package
gigabyte_waterforce:   Refresh:       2000 ms
```